### PR TITLE
Http Cross Origin Support

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,10 @@
 		"port": 3000,
 		"address": "0.0.0.0"
 	},
+	"accessControl": {
+		"allowOrigin": "*",
+		"allowMethods": "GET,POST,PUT,DELETE,HEAD,OPTIONS"
+	},
 	"flavor": "sproutcore",
 	"debug": true
 }

--- a/lib/accesscontrol.js
+++ b/lib/accesscontrol.js
@@ -1,0 +1,27 @@
+/* 
+    accesscontrol.js
+    mongodb-rest
+
+    Created by Benjamin Eidelman on 2011-04-05.
+		This file is part of mongodb-rest.
+*/ 
+var mongo = require("mongodb"),
+    config = module.parent.exports.config;
+
+/*
+ * accesscontrol - handles http access control based on configuration
+ */
+module.exports.handle = function(req, res, next) {
+	if (req.header('Origin')) {
+		if (config.accessControl.allowOrigin) {
+			res.header('Access-Control-Allow-Origin', config.accessControl.allowOrigin);
+		}
+		if (config.accessControl.allowMethods) {
+			res.header('Access-Control-Allow-Methods', config.accessControl.allowMethods);
+		}
+		if (req.header('Access-Control-Request-Headers')) {
+			res.header('Access-Control-Allow-Headers', req.header('Access-Control-Request-Headers'));
+		}
+	}
+	return next();	
+};

--- a/server.js
+++ b/server.js
@@ -25,14 +25,6 @@ var config = { "db": {
 
 var app = module.exports.app = express.createServer();
 
-app.configure(function(){
-    app.use(express.bodyParser());
-    app.use(express.static(__dirname + '/public'));
-    app.use(express.logger());
-    app.set('views', __dirname + '/views');
-    app.set('view engine', 'jade');
-});
-
 try {
   config = JSON.parse(fs.readFileSync(process.cwd()+"/config.json"));
 } catch(e) {
@@ -40,6 +32,19 @@ try {
 }
 
 module.exports.config = config;
+
+app.configure(function(){
+    app.use(express.bodyParser());
+    app.use(express.static(__dirname + '/public'));
+    app.use(express.logger());
+    app.set('views', __dirname + '/views');
+    app.set('view engine', 'jade');
+	
+	if (config.accessControl){
+		var accesscontrol = require('./lib/accesscontrol');
+		app.use(accesscontrol.handle);
+	}	
+});
 
 require('./lib/main');
 require('./lib/command');


### PR DESCRIPTION
In this commit I added the support for cross origin requests.
In order to allow this I added a block to config.json that enables cross-origin requests and allows to specify http methods allowed and an specific source domain ("*" means anyone).
I had to move the load of config.json earlier on the server startup to use this config values on the accesscontrol module I added.
Cross Origin http requests must contain an "Origin" header, most modern browsers already take care of this when a cross origin request is detected.

This allows to make ajax callbacks from a web browser (eg. with jquery) from pages in different domains that our server, typically this is used for creating javascript widgets (ie. Google Maps, Twitter box, etc.), or give access to other third party aplications.

ps: I'm a newbie to node.js (and to github!) so please don't hesitate in suggesting any modification. Regards
