### PR TITLE
Add support for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node server.js

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -40,7 +40,7 @@ app.get('/:db/:collection/:id?', function(req, res) {
           cursor.toArray(function(err, docs){
             var result = [];          
             if(req.params.id) {
-              if(docs.length > 0) {
+              if(docs != null && docs.length > 0) {
                 result = util.flavorize(docs[0], "out");
                 res.header('Content-Type', 'application/json');
                 res.send(result);
@@ -48,9 +48,11 @@ app.get('/:db/:collection/:id?', function(req, res) {
                 res.send(404);
               }
             } else {
-              docs.forEach(function(doc){
-                result.push(util.flavorize(doc, "out"));
-              });
+              if(docs != null) {
+                docs.forEach(function(doc){
+                  result.push(util.flavorize(doc, "out"));
+                });
+	      }
               res.header('Content-Type', 'application/json');
               res.send(result);
             }

--- a/server.js
+++ b/server.js
@@ -30,7 +30,8 @@ try {
 } catch(e) {
   // ignore
 }
-
+// Get the port configuration from the environment. Useful for PaaS solutions as Heroku.
+config.server.port = process.env.PORT || config.server.port;
 module.exports.config = config;
 
 app.configure(function(){


### PR DESCRIPTION
Heroku seems to get the port configuration from the environment. This way we get it form the environment if available.
